### PR TITLE
Rename Add Unit button to Add Topic

### DIFF
--- a/Unit_Planner_Querter_Increments_v2.html
+++ b/Unit_Planner_Querter_Increments_v2.html
@@ -92,7 +92,7 @@
   </div>
 
   <div id="unitsContainer"></div>
-  <button onclick="addUnit()">Add Unit</button>
+  <button onclick="addUnit()">Add Topic</button>
 
   <h2>Summary</h2>
   <p id="daysAllocated">Days allocated: 0</p>


### PR DESCRIPTION
## Summary
- Rename "Add Unit" button text to "Add Topic" while keeping existing `addUnit` function unchanged.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689533ca29d883239084c0538781c362